### PR TITLE
Add host Trash access for deleting files

### DIFF
--- a/org.kde.gwenview.json
+++ b/org.kde.gwenview.json
@@ -10,7 +10,8 @@
         "--filesystem=host",
         "--share=ipc",
         "--socket=fallback-x11",
-        "--socket=wayland"
+        "--socket=wayland",
+        "--filesystem=xdg-data/Trash"
     ],
     "cleanup": [
         "*.a",


### PR DESCRIPTION
Currently deleting files from the app interface results in those being put in `~/.var/app/org.kde.gwenview/data/Trash` which isn't useful or expected by users. Allowing access to hosts Trash solves this problem. For the future it should be investigated if using Trash portal is possible instead.