### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/org.kde.gwenview.json
+++ b/org.kde.gwenview.json
@@ -13,6 +13,7 @@
         "--filesystem=/run/media",
         "--filesystem=/var/run/media",
         "--filesystem=/var/mnt",
+        "--filesystem=/usr:ro",
         "--filesystem=xdg-data/Trash",
         "--share=ipc",
         "--socket=cups",


### PR DESCRIPTION
it should not have host access

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt