### PR TITLE
Add --filesystem=xdg-cache/thumbnails

### DIFF
--- a/org.kde.gwenview.json
+++ b/org.kde.gwenview.json
@@ -8,6 +8,7 @@
     "finish-args": [
         "--device=dri",
         "--filesystem=host",
+        "--filesystem=xdg-cache/thumbnails:rw",
         "--filesystem=xdg-data/Trash",
         "--share=ipc",
         "--socket=cups",


### PR DESCRIPTION
Grant access to thumbnail cache folder in home directory. This is safe as Gwenview already has access to everything (host) right now as it's not fully portal aware yet.

Fixes: https://github.com/flathub/org.kde.gwenview/issues/168