### PR TITLE
Use ffmpeg-full extension

### DIFF
--- a/org.kde.gwenview.json
+++ b/org.kde.gwenview.json
@@ -23,6 +23,17 @@
         "/lib/pkgconfig",
         "/share/man"
     ],
+    "add-extensions": {
+        "org.freedesktop.Platform.ffmpeg-full": {
+            "directory": "lib/ffmpeg",
+            "version": "24.08",
+            "add-ld-path": ".",
+            "no-autodownload": false
+        }
+    },
+    "cleanup-commands": [
+        "mkdir -p /app/lib/ffmpeg"
+    ],
     "modules": [
         {
             "name": "inih",


### PR DESCRIPTION
This adds support for heif/heic format

Fixes https://github.com/flathub/org.kde.gwenview/issues/158

Testing this requires `org.freedesktop.Platform.ffmpeg-full//24.08` installed. Auto installing of extension doesn't seem to work through test PR but should work during install/update of stable version post merge.